### PR TITLE
fix(documentation): README.MD indent annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,5 +63,5 @@ kind: Component
 metadata:
   # ...
   annotations:
-  dependencytrack/project-id: <project-id> # e63d5397-5e9e-494a-4755-368c2b1dc446
+    dependencytrack/project-id: <project-id> # e63d5397-5e9e-494a-4755-368c2b1dc446
 ```


### PR DESCRIPTION
I believe this is how the projectid should be applied, as an annotation? 
- Updated Documentation to show proper indentation for dependencytrack/project.
