### PR TITLE
fix(pkg): add pluginPackages and sideEffects via backstage-cli repo fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,8 +11,12 @@
   },
   "backstage": {
     "role": "frontend-plugin",
-    "pluginId": "dependencytrack"
+    "pluginId": "dependencytrack",
+    "pluginPackages": [
+      "@trimm/plugin-dependencytrack"
+    ]
   },
+  "sideEffects": false,
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",


### PR DESCRIPTION
The `backstage-cli package prepack` requires both `backstage.pluginPackages` and `sideEffects` fields. Generated by running `yarn backstage-cli repo fix --publish`.